### PR TITLE
feat(vscode-settings): add project-specific spell check exceptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cSpell.words": ["madlibs", "peerjs"]
+}


### PR DESCRIPTION
Add 'madlibs' and 'peerjs' to the cSpell dictionary to prevent spell check from flagging these terms as errors in VSCode.