### PR TITLE
refactor(session-display): SessionDisplay refactor and Cypress tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,8 +267,7 @@ function App(): ReactElement {
         <>
             <h1>Madlibs Generator</h1>
             <SessionDisplay
-                sessionId={sessionId}
-                peerId={peerId}
+                sessionId={sessionId ?? peerId}
                 handleCollaborateClick={handleCollaborateClick}
             />
             {canViewTemplate && (

--- a/src/SessionDisplay.cy.tsx
+++ b/src/SessionDisplay.cy.tsx
@@ -1,0 +1,33 @@
+import { v4 as uuidv4 } from 'uuid'
+import SessionDisplay from './SessionDisplay'
+
+describe('<SessionDisplay />', () => {
+    const testCases = [
+        { sessionId: uuidv4(), expectLink: true },
+        { sessionId: null, expectLink: false },
+    ]
+
+    testCases.forEach(({ sessionId, expectLink }) => {
+        it(`should ${
+            expectLink ? '' : 'not '
+        }render session link when sessionId is ${sessionId}`, () => {
+            const handleCollaborateClick = cy.stub().as('collaborateClick')
+            cy.mount(
+                <SessionDisplay
+                    sessionId={sessionId}
+                    handleCollaborateClick={handleCollaborateClick}
+                />,
+            )
+
+            if (expectLink) {
+                cy.get('.button-container a').should('have.text', sessionId)
+            } else {
+                cy.get('.button-container button')
+                    .should('exist')
+                    .and('have.text', 'Collaborate')
+                cy.get('.button-container button').click()
+                cy.get('@collaborateClick').should('have.been.calledOnce')
+            }
+        })
+    })
+})

--- a/src/SessionDisplay.tsx
+++ b/src/SessionDisplay.tsx
@@ -2,26 +2,18 @@ import React from 'react'
 
 interface SessionDisplayProps {
     sessionId: string | null
-    peerId: string | null
     handleCollaborateClick: () => void
 }
 
 const SessionDisplay: React.FC<SessionDisplayProps> = ({
     sessionId,
-    peerId,
     handleCollaborateClick,
 }) => {
-    const getId = (): string => {
-        if (sessionId != null) return sessionId
-        else if (peerId != null) return peerId
-        else return ''
-    }
-
     const sessionIdComponent = (
         <div className="button-container">
             Session:{' '}
-            <a href={`${window.location.href}?sessionId=${getId()}`}>
-                {getId()}
+            <a href={`${window.location.href}?sessionId=${sessionId}`}>
+                {sessionId}
             </a>
         </div>
     )
@@ -33,7 +25,11 @@ const SessionDisplay: React.FC<SessionDisplayProps> = ({
     )
 
     return (
-        <>{getId() !== '' ? sessionIdComponent : collaborationBttnComponent}</>
+        <>
+            {sessionId !== null
+                ? sessionIdComponent
+                : collaborationBttnComponent}
+        </>
     )
 }
 


### PR DESCRIPTION
This commit simplifies the session or peer ID display logic in the `SessionDisplay` component. Previously, the code separately handled `sessionId` and `peerId`, providing a fallback mechanism in a multi-step conditional function (`getId`). With this refactor, the component now directly uses `sessionId ?? peerId` to achieve the same goal with less complexity.

Additionally, a new Cypress test file `src/SessionDisplay.cy.tsx` has been added to ensure the `SessionDisplay` component behaves correctly, verifying whether a session link is rendered based on the existence of the `sessionId`.

The changes include:
- Removal of `peerId` from `SessionDisplayProps` and all associated logic that conditionally determined which ID to display.
- The SessionDisplay` component now uses a single line to handle the potential fallback from `sessionId` to `peerId`.
- Creation of a new Cypress test suite for `SessionDisplay`, testing if the session link or collaborate button renders appropriately depending on the presence of the `sessionId`.