### PR TITLE
refactor(input-fields): remove formatPlaceholder from InputFields props 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,14 +183,6 @@ function App(): ReactElement {
         sendTemplateMessage(newTemplate)
     }
 
-    // Function to convert placeholder id to a more readable format
-    const formatPlaceholder = (id: string): string => {
-        return id
-            .split('-')
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' ')
-    }
-
     const handleInputChange = (name: string, value: string): void => {
         setInputs((inputs) => ({ ...inputs, [name]: value }))
         sendInputMessage(name, value)
@@ -287,7 +279,6 @@ function App(): ReactElement {
                     inputs={inputs}
                     handleInputChange={handleInputChange}
                     sanitizeField={sanitizeField}
-                    formatPlaceholder={formatPlaceholder}
                 />
             </div>
             <div className="button-container">

--- a/src/InputFields.cy.tsx
+++ b/src/InputFields.cy.tsx
@@ -1,52 +1,54 @@
 import InputFields from './InputFields'
 
 describe('<InputFields />', () => {
-    interface TestData {
+    interface TestCase {
         inputs: Record<string, string>
+        placeholders: string[]
     }
-    const testDataArray: TestData[] = [
+    const testCases: TestCase[] = [
         {
             inputs: { foo: 'bar' },
+            placeholders: ['Foo'],
         },
         {
             inputs: { foo: 'bar', baz: 'qux' },
+            placeholders: ['Foo', 'Baz'],
         },
         {
             inputs: { foo: 'bar', baz: '' },
+            placeholders: ['Foo'],
         },
     ]
-    testDataArray.forEach((testData) => {
+    testCases.forEach((testCase) => {
         it('renders inputs with a values and placeholders', () => {
             const handleInputChange = cy.stub()
             const sanitizeField = cy
                 .stub()
                 .callsFake((x: string) => `sanitized-${x}`)
-            const formatPlaceholder = cy
-                .stub()
-                .callsFake((x: string) => `${x}-placeholder`)
             cy.mount(
                 <InputFields
-                    inputs={testData.inputs}
+                    inputs={testCase.inputs}
                     handleInputChange={handleInputChange}
                     sanitizeField={sanitizeField}
-                    formatPlaceholder={formatPlaceholder}
                 />,
             ).then(() => {
                 cy.get('input').should(
                     'have.length',
-                    Object.keys(testData.inputs).length,
+                    Object.keys(testCase.inputs).length,
                 )
-                Object.keys(testData.inputs).forEach((name, index) => {
+                Object.keys(testCase.inputs).forEach((name, index) => {
                     cy.get('input')
                         .eq(index)
-                        .should('have.value', testData.inputs[name])
+                        .should('have.value', testCase.inputs[name])
                 })
-                Object.keys(testData.inputs).forEach((name, index) => {
-                    cy.get('input')
-                        .eq(index)
-                        .should('have.attr', 'placeholder')
-                        .and('equal', `${name}-placeholder`)
-                })
+                testCase.placeholders.forEach(
+                    (placeholder, index) => {
+                        cy.get('input')
+                            .eq(index)
+                            .should('have.attr', 'placeholder')
+                            .and('equal', placeholder)
+                    },
+                )
             })
         })
         it('sanitizeInput', () => {
@@ -54,52 +56,18 @@ describe('<InputFields />', () => {
             const sanitizeField = cy
                 .stub()
                 .callsFake((x: string) => `sanitized-${x}`)
-            const formatPlaceholder = cy
-                .stub()
-                .callsFake((x: string) => `${x}-placeholder`)
             cy.mount(
                 <InputFields
-                    inputs={testData.inputs}
+                    inputs={testCase.inputs}
                     handleInputChange={handleInputChange}
                     sanitizeField={sanitizeField}
-                    formatPlaceholder={formatPlaceholder}
                 />,
             ).then(() => {
                 expect(sanitizeField).to.be.callCount(
-                    Object.keys(testData.inputs).length,
+                    Object.keys(testCase.inputs).length,
                 )
-                Object.keys(testData.inputs).forEach((name) => {
+                Object.keys(testCase.inputs).forEach((name) => {
                     expect(sanitizeField).to.be.calledWith(name)
-                })
-            })
-        })
-        it('formatPlaceholder', () => {
-            const handleInputChange = cy.stub()
-            const sanitizeField = cy
-                .stub()
-                .callsFake((x: string) => `sanitized-${x}`)
-            const formatPlaceholder = cy
-                .stub()
-                .callsFake((x: string) => `${x}-placeholder`)
-            cy.mount(
-                <InputFields
-                    inputs={testData.inputs}
-                    handleInputChange={handleInputChange}
-                    sanitizeField={sanitizeField}
-                    formatPlaceholder={formatPlaceholder}
-                />,
-            ).then(() => {
-                expect(formatPlaceholder).to.be.callCount(
-                    Object.keys(testData.inputs).length,
-                )
-                Object.keys(testData.inputs).forEach((name) => {
-                    expect(formatPlaceholder).to.be.calledWith(name)
-                })
-                Object.keys(testData.inputs).forEach((name, index) => {
-                    cy.get('input')
-                        .eq(index)
-                        .should('have.attr', 'placeholder')
-                        .and('equal', `${name}-placeholder`)
                 })
             })
         })

--- a/src/InputFields.tsx
+++ b/src/InputFields.tsx
@@ -4,14 +4,20 @@ interface InputFieldsProps {
     inputs: Record<string, string>
     handleInputChange: (name: string, value: string) => void
     sanitizeField: (field: string) => string
-    formatPlaceholder: (id: string) => string
+}
+
+// Function to convert placeholder id to a more readable format
+const formatPlaceholder = (id: string): string => {
+    return id
+        .split('-')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
 }
 
 const InputFields: React.FC<InputFieldsProps> = ({
     inputs,
     handleInputChange,
     sanitizeField,
-    formatPlaceholder,
 }) => {
     return (
         <>


### PR DESCRIPTION
…standalone

Remove the `formatPlaceholder` function from being passed as a prop in the InputFields component, replacing it with a standalone function within the InputFields module. Also update the relevant tests to account for this change by including predefined placeholders instead of generating them within the tests.

- Removed `formatPlaceholder` dependency from App.tsx and InputFields.cy.tsx.
- Created a separate `formatPlaceholder` function inside InputFields.tsx.
- Changed test data structure within InputFields.cy.tsx to include explicit `placeholders`.
- Cleaned up unnecessary tests related to placeholder formatting from InputFields.cy.tsx.

This refactor simplifies the components' interfaces by reducing prop drilling and improves test predictability by using fixed placeholders.