### PR TITLE
refactor(input-fields): remove prop sanitizeField from InputFields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -243,10 +243,6 @@ function App(): ReactElement {
         setStory(storyTemplate)
     }
 
-    const sanitizeField = (field: string): string => {
-        return field.replace(/[^a-zA-Z0-9-_]/g, '')
-    }
-
     // Check conditions for enabling the "Generate Story" button
     const canViewTemplate = sessionId === null
 
@@ -278,7 +274,6 @@ function App(): ReactElement {
                 <InputFields
                     inputs={inputs}
                     handleInputChange={handleInputChange}
-                    sanitizeField={sanitizeField}
                 />
             </div>
             <div className="button-container">

--- a/src/InputFields.cy.tsx
+++ b/src/InputFields.cy.tsx
@@ -4,32 +4,37 @@ describe('<InputFields />', () => {
     interface TestCase {
         inputs: Record<string, string>
         placeholders: string[]
+        names: string[]
     }
     const testCases: TestCase[] = [
         {
-            inputs: { foo: 'bar' },
-            placeholders: ['Foo'],
+            inputs: { 'foo-1': 'bar' }, // this checks formatPlaceholder
+            placeholders: ['Foo 1'],
+            names: ['foo-1'],
         },
         {
             inputs: { foo: 'bar', baz: 'qux' },
             placeholders: ['Foo', 'Baz'],
+            names: ['foo', 'baz'],
         },
         {
             inputs: { foo: 'bar', baz: '' },
             placeholders: ['Foo'],
+            names: ['foo'],
+        },
+        {
+            inputs: { foo$: 'bar', baz: '' }, // this checks sanitizeField
+            placeholders: ['Foo$'],
+            names: ['foo', 'baz'],
         },
     ]
     testCases.forEach((testCase) => {
         it('renders inputs with a values and placeholders', () => {
             const handleInputChange = cy.stub()
-            const sanitizeField = cy
-                .stub()
-                .callsFake((x: string) => `sanitized-${x}`)
             cy.mount(
                 <InputFields
                     inputs={testCase.inputs}
                     handleInputChange={handleInputChange}
-                    sanitizeField={sanitizeField}
                 />,
             ).then(() => {
                 cy.get('input').should(
@@ -41,33 +46,17 @@ describe('<InputFields />', () => {
                         .eq(index)
                         .should('have.value', testCase.inputs[name])
                 })
-                testCase.placeholders.forEach(
-                    (placeholder, index) => {
-                        cy.get('input')
-                            .eq(index)
-                            .should('have.attr', 'placeholder')
-                            .and('equal', placeholder)
-                    },
-                )
-            })
-        })
-        it('sanitizeInput', () => {
-            const handleInputChange = cy.stub()
-            const sanitizeField = cy
-                .stub()
-                .callsFake((x: string) => `sanitized-${x}`)
-            cy.mount(
-                <InputFields
-                    inputs={testCase.inputs}
-                    handleInputChange={handleInputChange}
-                    sanitizeField={sanitizeField}
-                />,
-            ).then(() => {
-                expect(sanitizeField).to.be.callCount(
-                    Object.keys(testCase.inputs).length,
-                )
-                Object.keys(testCase.inputs).forEach((name) => {
-                    expect(sanitizeField).to.be.calledWith(name)
+                testCase.placeholders.forEach((placeholder, index) => {
+                    cy.get('input')
+                        .eq(index)
+                        .should('have.attr', 'placeholder')
+                        .and('equal', placeholder)
+                })
+                testCase.names.forEach((name, index) => {
+                    cy.get('input')
+                        .eq(index)
+                        .should('have.attr', 'name')
+                        .and('equal', name)
                 })
             })
         })

--- a/src/InputFields.tsx
+++ b/src/InputFields.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 interface InputFieldsProps {
     inputs: Record<string, string>
     handleInputChange: (name: string, value: string) => void
-    sanitizeField: (field: string) => string
 }
 
 // Function to convert placeholder id to a more readable format
@@ -14,10 +13,13 @@ const formatPlaceholder = (id: string): string => {
         .join(' ')
 }
 
+const sanitizeField = (field: string): string => {
+    return field.replace(/[^a-zA-Z0-9-_]/g, '')
+}
+
 const InputFields: React.FC<InputFieldsProps> = ({
     inputs,
     handleInputChange,
-    sanitizeField,
 }) => {
     return (
         <>


### PR DESCRIPTION
This commit moves the `sanitizeField` function inside the `InputFields.tsx` component, eliminating it as a prop from both the `App.tsx` parent component and the related test file `InputFields.cy.tsx`. The aim was to encapsulate the sanitization logic within the component where it is actually used, thereby simplifying the interface between `App.tsx` and `InputFields.tsx` and reducing the passing around of callback functions. This change could potentially affect how other components interact with `InputFields`, assuming they relied on the sanitation to be performed externally. Additional updates in the testing file reflect this internalization, removing tests for external sanitization calls and verifying input element attributes directly related to the `names` array which was added to the test cases.