### PR TITLE
feat(template-input): streamline props and constants for inputs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,9 +263,6 @@ function App(): ReactElement {
                         onFileUpload={handleTemplateUpload}
                         onManualInput={handleManualTemplateInput}
                         inputData={template}
-                        fileInputLabel="Upload Story Template"
-                        textAreaPlaceholder="Type your {awesome} template here! Use curly braces to indicate placeholders."
-                        infoText="Use curly braces {} to indicate placeholders in the template. For example, {noun}, {verb}, {adjective}."
                     />
                 </div>
             )}

--- a/src/FileUpload.cy.tsx
+++ b/src/FileUpload.cy.tsx
@@ -4,27 +4,12 @@ import FileUpload from './FileUpload'
 describe('<FileUpload />', () => {
     const testCases = [
         {
-            description: 'label and no info text',
-            label: 'Upload File',
-            infoText: undefined,
+            description: 'active state',
             disabled: false,
         },
+
         {
-            description: 'label and info text',
-            label: 'Profile Picture',
-            infoText: 'Please upload an image file',
-            disabled: false,
-        },
-        {
-            description: 'label and disabled state',
-            label: 'Document',
-            infoText: undefined,
-            disabled: true,
-        },
-        {
-            description: 'label, info text, and disabled state',
-            label: 'Resume',
-            infoText: 'Supported formats: PDF, DOCX',
+            description: 'disabled state',
             disabled: true,
         },
     ]
@@ -33,23 +18,20 @@ describe('<FileUpload />', () => {
         it(`renders with ${testCase.description}`, () => {
             cy.mount(
                 <FileUpload
-                    label={testCase.label}
                     onChange={cy.stub()}
                     disabled={testCase.disabled}
-                    infoText={testCase.infoText}
                 />,
             ).then(() => {
                 // Verify the label text
-                cy.get('.upload-box label').should(
-                    'have.text',
-                    `${testCase.label}:`,
-                )
-                // Verify label is correctly associated with file input
-                cy.get('.upload-box label').should(
-                    'have.attr',
-                    'for',
-                    testCase.label.toLowerCase().replace(/\s+/g, '-'),
-                )
+                cy.get('.upload-box label').should('exist')
+
+                cy.get('input').invoke('attr', 'id').as('input_id')
+                cy.get('label').invoke('attr', 'for').as('label_id')
+                cy.get('@input_id').then((inputId) => {
+                    cy.get('@label_id').then((labelId) => {
+                        expect(inputId).equal(labelId)
+                    })
+                })
 
                 // Verify the presence of the file input
                 cy.get('.upload-box input[type="file"]').should('exist')
@@ -65,51 +47,43 @@ describe('<FileUpload />', () => {
                     )
                 }
 
-                // Verify the presence of info text if applicable
-                if (testCase.infoText != null) {
-                    cy.get('.info-icon').should(
-                        'have.attr',
-                        'title',
-                        testCase.infoText,
-                    )
-                } else {
-                    cy.get('.info-icon').should('not.exist')
-                }
+                // Verify the presence of info text
+                cy.get('.info-icon')
+                    .should('exist')
+                    .should('have.attr', 'title')
             })
         })
     })
     it('calls onChange handler with file data on file upload', () => {
         const onChangeStub = cy.stub()
-        cy.mount(
-            <FileUpload
-                label="Test File Upload"
-                onChange={onChangeStub}
-                disabled={false}
-                infoText="Upload a file"
-            />,
-        ).then(() => {
-            // Simulate file upload process
-            const dummyFile = new File(['content'], 'testfile.txt', {
-                type: 'text/plain',
-            })
-            cy.get('input[type="file"]')
-                .selectFile({ contents: dummyFile, fileName: 'testfile.txt' })
-                .then(() => {
-                    // Check if the onChange function is called with the correct file
-                    expect(onChangeStub).to.be.calledWithMatch(
-                        (event: ChangeEvent<HTMLInputElement>) => {
-                            if (
-                                event.target.files !== null &&
-                                event.target.files?.length > 0
-                            ) {
-                                return (
-                                    event.target.files[0].name ===
-                                    'testfile.txt'
-                                )
-                            }
-                        },
-                    )
+        cy.mount(<FileUpload onChange={onChangeStub} disabled={false} />).then(
+            () => {
+                // Simulate file upload process
+                const dummyFile = new File(['content'], 'testfile.txt', {
+                    type: 'text/plain',
                 })
-        })
+                cy.get('input[type="file"]')
+                    .selectFile({
+                        contents: dummyFile,
+                        fileName: 'testfile.txt',
+                    })
+                    .then(() => {
+                        // Check if the onChange function is called with the correct file
+                        expect(onChangeStub).to.be.calledWithMatch(
+                            (event: ChangeEvent<HTMLInputElement>) => {
+                                if (
+                                    event.target.files !== null &&
+                                    event.target.files?.length > 0
+                                ) {
+                                    return (
+                                        event.target.files[0].name ===
+                                        'testfile.txt'
+                                    )
+                                }
+                            },
+                        )
+                    })
+            },
+        )
     })
 })

--- a/src/FileUpload.tsx
+++ b/src/FileUpload.tsx
@@ -1,29 +1,29 @@
 import React from 'react'
 
+const FILE_INPUT_LABEL = 'Upload Story Template'
+const INFO_TEXT =
+    'Use curly braces {} to indicate placeholders in the template. For example, {noun}, {verb}, {adjective}.'
+
 interface FileUploadProps {
-    label: string
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
     disabled?: boolean
-    infoText?: string
 }
 
 const FileUpload: React.FC<FileUploadProps> = ({
-    label,
     onChange,
     disabled = false,
-    infoText,
 }) => {
-    const id = label.toLowerCase().replace(/\s+/g, '-')
+    const id = FILE_INPUT_LABEL.toLowerCase().replace(/\s+/g, '-')
     const infoIconComponent = (
-        <span className="info-icon" title={infoText}>
+        <span className="info-icon" title={INFO_TEXT}>
             &#9432;
         </span>
     )
 
     return (
         <div className="upload-box">
-            <label htmlFor={id}>{label}:</label>
-            {infoText != null && infoIconComponent}
+            <label htmlFor={id}>{FILE_INPUT_LABEL}:</label>
+            {infoIconComponent}
             <input
                 type="file"
                 id={id}

--- a/src/TemplateInput.cy.tsx
+++ b/src/TemplateInput.cy.tsx
@@ -3,60 +3,29 @@ import TemplateInput from './TemplateInput'
 interface TestCase {
     description: string
     inputData: string
-    infoText?: string
-    fileInputLabel: string
-    textAreaPlaceholder: string
     expectFileUpload: boolean
 }
 describe('<TemplateInput />', () => {
     const testCases: TestCase[] = [
         {
-            description: 'File upload mode, no input, info text present',
-            inputData: '',
-            infoText: 'Sample info text',
-            fileInputLabel: 'Upload File',
-            textAreaPlaceholder: 'Enter text manually',
+            description: 'File upload mode, no input',
             expectFileUpload: true,
+            inputData: '',
         },
         {
-            description: 'File upload mode, no input, no info text',
+            description: 'Text input mode, no input',
+            expectFileUpload: false,
             inputData: '',
-            infoText: undefined,
-            fileInputLabel: 'Upload File',
-            textAreaPlaceholder: 'Enter text manually',
+        },
+        {
+            description: 'File upload mode, with input',
             expectFileUpload: true,
-        },
-        {
-            description: 'Text input mode, no input, info text present',
-            inputData: '',
-            infoText: 'Sample info text',
-            fileInputLabel: 'Upload File',
-            textAreaPlaceholder: 'Enter text manually',
-            expectFileUpload: false,
-        },
-        {
-            description: 'Text input mode, no input, no info text',
-            inputData: '',
-            infoText: undefined,
-            fileInputLabel: 'Upload File',
-            textAreaPlaceholder: 'Enter text manually',
-            expectFileUpload: false,
-        },
-        {
-            description: 'File upload mode, with input, info text present',
             inputData: 'Sample text',
-            infoText: 'Sample info text',
-            fileInputLabel: 'Upload File',
-            textAreaPlaceholder: 'Enter text manually',
-            expectFileUpload: true,
         },
         {
-            description: 'Text input mode, with input, info text present',
-            inputData: 'Sample text',
-            infoText: 'Sample info text',
-            fileInputLabel: 'Upload File',
-            textAreaPlaceholder: 'Enter text manually',
+            description: 'Text input mode, with input',
             expectFileUpload: false,
+            inputData: 'Sample text',
         },
     ]
 
@@ -67,9 +36,6 @@ describe('<TemplateInput />', () => {
                     onFileUpload={cy.stub()}
                     onManualInput={cy.stub()}
                     inputData={testCase.inputData}
-                    infoText={testCase.infoText}
-                    fileInputLabel={testCase.fileInputLabel}
-                    textAreaPlaceholder={testCase.textAreaPlaceholder}
                 />,
             ).then(() => {
                 if (testCase.expectFileUpload) {
@@ -84,23 +50,6 @@ describe('<TemplateInput />', () => {
                             )
                             // Verify that the FileUpload component is present after the click
                             cy.get('.upload-box').should('exist')
-                            // Verify the file input label
-                            cy.get('.upload-box>label').should(
-                                'have.text',
-                                `${testCase.fileInputLabel}:`,
-                            )
-
-                            if (testCase.infoText !== undefined) {
-                                // Verify that the info text is displayed
-                                cy.get('.info-icon').should(
-                                    'have.attr',
-                                    'title',
-                                    testCase.infoText,
-                                )
-                            } else {
-                                // Verify that the info text element is absent
-                                cy.get('.info-icon').should('not.exist')
-                            }
                         })
                 } else {
                     // Verify the button text
@@ -108,13 +57,14 @@ describe('<TemplateInput />', () => {
                         'have.text',
                         'Upload File',
                     )
-                    // Verify that the text area is present with the correct placeholder
+                    // Verify that the text area is present
                     cy.get('textarea')
-                        .should(
-                            'have.attr',
-                            'placeholder',
-                            testCase.textAreaPlaceholder,
-                        )
+                        .should('exist')
+                        .should('have.attr', 'placeholder')
+
+                    // Verify that the text area has expected value
+                    cy.get('textarea')
+                        .should('exist')
                         .and('have.value', testCase.inputData)
                 }
             })
@@ -126,9 +76,6 @@ describe('<TemplateInput />', () => {
                 onFileUpload={cy.stub()}
                 onManualInput={cy.stub()}
                 inputData=""
-                infoText="Some info text"
-                fileInputLabel="Upload a file"
-                textAreaPlaceholder="Enter text here"
             />,
         ).then(() => {
             // Initially, the TextArea should be visible
@@ -159,9 +106,6 @@ describe('<TemplateInput />', () => {
                 onFileUpload={fileUploadStub}
                 onManualInput={cy.stub()}
                 inputData=""
-                infoText="Some info text"
-                fileInputLabel="Upload a file"
-                textAreaPlaceholder="Enter text here"
             />,
         ).then(() => {
             // Initially switch to FileUpload component
@@ -204,9 +148,6 @@ describe('<TemplateInput />', () => {
                 onFileUpload={cy.stub()}
                 onManualInput={manualInputStub}
                 inputData=""
-                infoText="Some info text"
-                fileInputLabel="Upload a file"
-                textAreaPlaceholder="Enter text here"
             />,
         ).then(() => {
             // Type some text into the textarea

--- a/src/TemplateInput.tsx
+++ b/src/TemplateInput.tsx
@@ -5,18 +5,15 @@ interface TemplateInputProps {
     onFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => void
     onManualInput: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
     inputData: string
-    infoText?: string
-    fileInputLabel: string
-    textAreaPlaceholder: string
 }
+
+const TEXT_AREA_PLACEHOLDER =
+    'Type your {awesome} template here! Use curly braces to indicate placeholders.'
 
 const TemplateInput: React.FC<TemplateInputProps> = ({
     onFileUpload,
     onManualInput,
     inputData,
-    infoText,
-    fileInputLabel,
-    textAreaPlaceholder,
 }) => {
     const [useFileUpload, setUseFileUpload] = useState(false)
 
@@ -26,16 +23,14 @@ const TemplateInput: React.FC<TemplateInputProps> = ({
 
     const fileUploadComponent = (
         <FileUpload
-            label={fileInputLabel}
             onChange={onFileUpload}
-            infoText={infoText}
         />
     )
     const textInputComponent = (
         <textarea
             value={inputData}
             onChange={onManualInput}
-            placeholder={textAreaPlaceholder}
+            placeholder={TEXT_AREA_PLACEHOLDER}
         />
     )
 


### PR DESCRIPTION
Refactor `FileUpload` and `TemplateInput` components to use internal constants instead of passing props for static values. Removed unnecessary info text and placeholders from the Cypress tests to match component changes, ensuring that tests are now aligned with the updated component structure.

The removal of dynamic prop passing for static textual content simplifies component interfaces and promotes consistency. The commit also includes adjustments in related Cypress test cases to reflect the interface updates without affecting the overall functionality of the components.